### PR TITLE
feat(admin): auth guard + plan override backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ GOOGLE_PLACES_API_KEY=
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Admin (comma-separated emails)
+ADMIN_EMAILS=
+
 # Sentry
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_ORG=

--- a/e2e/admin-auth.spec.ts
+++ b/e2e/admin-auth.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Admin Auth Protection", () => {
+  test("admin redirects unauthenticated users to login", async ({ page }) => {
+    await page.goto("/admin");
+    await page.waitForURL(/\/login/);
+    expect(page.url()).toContain("/login");
+  });
+
+  test("admin subpages redirect to login", async ({ page }) => {
+    await page.goto("/admin/practices");
+    await page.waitForURL(/\/login/);
+    expect(page.url()).toContain("/login");
+  });
+});

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,45 @@
+import { Building2, BarChart3, Shield } from "lucide-react";
+import Link from "next/link";
+
+export default function AdminPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+        <p className="text-muted-foreground">
+          PraxisPuls Verwaltung – internes Admin-Panel.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Link
+          href="/admin/practices"
+          className="rounded-lg border bg-white p-6 shadow-sm hover:shadow-md transition-shadow"
+        >
+          <Building2 className="h-8 w-8 text-primary mb-3" />
+          <h2 className="font-semibold">Praxen</h2>
+          <p className="text-sm text-muted-foreground">
+            Alle Praxen verwalten, Plans überschreiben.
+          </p>
+        </Link>
+
+        <Link
+          href="/admin/stats"
+          className="rounded-lg border bg-white p-6 shadow-sm hover:shadow-md transition-shadow"
+        >
+          <BarChart3 className="h-8 w-8 text-primary mb-3" />
+          <h2 className="font-semibold">Statistiken</h2>
+          <p className="text-sm text-muted-foreground">
+            Plattform-Metriken, Audit-Logs, Login-Events.
+          </p>
+        </Link>
+
+        <div className="rounded-lg border bg-white p-6 shadow-sm opacity-60">
+          <Shield className="h-8 w-8 text-muted-foreground mb-3" />
+          <h2 className="font-semibold text-muted-foreground">Security</h2>
+          <p className="text-sm text-muted-foreground">Kommt in v0.2.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import { getUser } from "@/lib/auth";
+import { LogoutButton } from "@/components/dashboard/logout-button";
+import { BuildBadge } from "@/components/shared/build-badge";
+import {
+  LayoutDashboard,
+  Building2,
+  BarChart3,
+  ArrowLeft,
+} from "lucide-react";
+
+const adminNavItems = [
+  { href: "/admin", label: "Übersicht", icon: LayoutDashboard },
+  { href: "/admin/practices", label: "Praxen", icon: Building2 },
+  { href: "/admin/stats", label: "Statistiken", icon: BarChart3 },
+];
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getUser();
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Sidebar */}
+      <aside className="hidden w-64 flex-shrink-0 border-r bg-slate-900 md:block">
+        <div className="flex h-full flex-col">
+          <div className="flex h-16 items-center border-b border-slate-700 px-6">
+            <Link href="/admin" className="text-xl font-bold text-white">
+              PraxisPuls <span className="text-xs font-normal text-slate-400">Admin</span>
+            </Link>
+          </div>
+
+          <nav className="flex-1 space-y-1 px-3 py-4">
+            {adminNavItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-slate-300 hover:bg-slate-800 hover:text-white"
+              >
+                <item.icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+
+          <div className="border-t border-slate-700 p-4 space-y-2">
+            <Link
+              href="/dashboard"
+              className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-slate-400 hover:bg-slate-800 hover:text-white"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Zurück zum Dashboard
+            </Link>
+            <div className="flex items-center gap-3 px-1 py-1">
+              <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-slate-700 text-xs font-medium text-white">
+                {user.email?.charAt(0).toUpperCase()}
+              </div>
+              <p className="flex-1 truncate text-xs text-slate-400">{user.email}</p>
+            </div>
+            <LogoutButton />
+            <div className="px-1 pt-1">
+              <BuildBadge />
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <div className="flex flex-1 flex-col">
+        <header className="flex h-16 items-center justify-between border-b bg-white px-6 md:hidden">
+          <Link href="/admin" className="text-lg font-bold">
+            Admin
+          </Link>
+          <LogoutButton variant="icon" />
+        </header>
+
+        <main className="flex-1 overflow-y-auto bg-gray-50 p-4 md:p-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/public/responses/route.ts
+++ b/src/app/api/public/responses/route.ts
@@ -7,7 +7,7 @@ import { routeByNps } from "@/lib/review-router";
 import { eq, and } from "drizzle-orm";
 import { getMonthlyResponseCount } from "@/lib/db/queries/dashboard";
 import { PLAN_LIMITS } from "@/types";
-import type { PlanId } from "@/types";
+import { getEffectivePlan } from "@/lib/plans";
 import { sendDetractorAlert } from "@/lib/email";
 
 export async function POST(request: Request) {
@@ -59,7 +59,7 @@ export async function POST(request: Request) {
     }
 
     // Check plan limits
-    const planId = (practice.plan || "free") as PlanId;
+    const planId = getEffectivePlan(practice);
     const limits = PLAN_LIMITS[planId];
     const monthlyCount = await getMonthlyResponseCount(practice.id);
 

--- a/src/lib/__tests__/plans.test.ts
+++ b/src/lib/__tests__/plans.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { getEffectivePlan } from "@/lib/plans";
+
+describe("getEffectivePlan", () => {
+  it("returns override when set and not expired", () => {
+    const result = getEffectivePlan({
+      plan: "free",
+      planOverride: "professional",
+      overrideExpiresAt: new Date(Date.now() + 86400000), // tomorrow
+    });
+    expect(result).toBe("professional");
+  });
+
+  it("returns override when no expiry set (permanent override)", () => {
+    const result = getEffectivePlan({
+      plan: "free",
+      planOverride: "starter",
+      overrideExpiresAt: null,
+    });
+    expect(result).toBe("starter");
+  });
+
+  it("returns Stripe plan when override is expired", () => {
+    const result = getEffectivePlan({
+      plan: "starter",
+      planOverride: "professional",
+      overrideExpiresAt: new Date(Date.now() - 86400000), // yesterday
+    });
+    expect(result).toBe("starter");
+  });
+
+  it("returns Stripe plan when no override set", () => {
+    const result = getEffectivePlan({
+      plan: "professional",
+      planOverride: null,
+      overrideExpiresAt: null,
+    });
+    expect(result).toBe("professional");
+  });
+
+  it('returns "free" when no plan and no override', () => {
+    const result = getEffectivePlan({
+      plan: null,
+      planOverride: null,
+      overrideExpiresAt: null,
+    });
+    expect(result).toBe("free");
+  });
+
+  it('returns "free" when plan is empty string', () => {
+    const result = getEffectivePlan({
+      plan: "",
+      planOverride: null,
+      overrideExpiresAt: null,
+    });
+    expect(result).toBe("free");
+  });
+
+  it("handles string date for overrideExpiresAt (from DB)", () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const result = getEffectivePlan({
+      plan: "free",
+      planOverride: "professional",
+      overrideExpiresAt: new Date(future),
+    });
+    expect(result).toBe("professional");
+  });
+});

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -32,6 +32,9 @@ export const practices = pgTable(
     alertEmail: text("alert_email"),
     surveyTemplate: text("survey_template").default("zahnarzt_standard"),
     theme: text("theme").default("standard"), // standard | vertrauen
+    planOverride: text("plan_override"), // free | starter | professional (admin-set)
+    overrideReason: text("override_reason"),
+    overrideExpiresAt: timestamp("override_expires_at", { withTimezone: true }),
     npsThreshold: smallint("nps_threshold").default(9),
     googleRedirectEnabled: boolean("google_redirect_enabled").default(true),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,24 @@
+import type { Practice } from "@/lib/db/schema";
+import type { PlanId } from "@/types";
+
+/**
+ * Determine the effective plan for a practice.
+ * Priority: active override > Stripe plan > "free"
+ */
+export function getEffectivePlan(
+  practice: Pick<Practice, "plan" | "planOverride" | "overrideExpiresAt">
+): PlanId {
+  // Check for active (non-expired) override
+  if (practice.planOverride) {
+    const now = new Date();
+    const expired =
+      practice.overrideExpiresAt && new Date(practice.overrideExpiresAt) < now;
+
+    if (!expired) {
+      return practice.planOverride as PlanId;
+    }
+  }
+
+  // Fall back to Stripe plan or free
+  return (practice.plan as PlanId) || "free";
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -37,12 +37,27 @@ export async function updateSession(request: NextRequest) {
   // Protected routes: redirect to login if not authenticated
   const isProtectedRoute =
     request.nextUrl.pathname.startsWith("/dashboard") ||
-    request.nextUrl.pathname.startsWith("/onboarding");
+    request.nextUrl.pathname.startsWith("/onboarding") ||
+    request.nextUrl.pathname.startsWith("/admin");
 
   if (!user && isProtectedRoute) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);
+  }
+
+  // Admin routes: require ADMIN_EMAILS
+  if (user && request.nextUrl.pathname.startsWith("/admin")) {
+    const adminEmails = (process.env.ADMIN_EMAILS || "")
+      .split(",")
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean);
+
+    if (!user.email || !adminEmails.includes(user.email.toLowerCase())) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/dashboard";
+      return NextResponse.redirect(url);
+    }
   }
 
   // Redirect logged-in users away from auth pages


### PR DESCRIPTION
## Summary
- Add ADMIN_EMAILS-based middleware guard for `/admin/*` routes (non-admins → `/dashboard`)
- Add `planOverride`, `overrideReason`, `overrideExpiresAt` columns to practices schema
- Add `getEffectivePlan()` utility with priority: active override > Stripe plan > "free"
- Add admin layout (dark sidebar) with placeholder dashboard page
- Replace direct `practice.plan` usage in public responses route with `getEffectivePlan()`

## Test plan
- [x] Unit tests: 7 tests for `getEffectivePlan()` (override, expired, no override, fallback)
- [x] E2E tests: admin routes redirect unauthenticated users to `/login`
- [x] All 111 unit tests pass
- [x] TypeScript strict: no errors
- [x] Build clean

## Next steps
- #22 Admin Practices UI (builds on this)
- #23 Admin Stats Dashboard (builds on this)
- `npm run db:push` to apply schema changes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)