### PR TITLE
fix(admin): add requireAdmin() auth check for server actions

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -56,7 +56,7 @@ export default async function AdminLayout({
             </Link>
             <div className="flex items-center gap-3 px-1 py-1">
               <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-slate-700 text-xs font-medium text-white">
-                {user.email?.charAt(0).toUpperCase()}
+                {user.email?.charAt(0).toUpperCase() || "?"}
               </div>
               <p className="flex-1 truncate text-xs text-slate-400">{user.email}</p>
             </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,3 +30,23 @@ export async function getUserOptional() {
   } = await supabase.auth.getUser();
   return user;
 }
+
+/**
+ * Require the current user to be an admin.
+ * Throws if not authenticated or not in ADMIN_EMAILS.
+ * Use in Server Actions that perform admin operations.
+ */
+export async function requireAdmin() {
+  const user = await getUser();
+
+  const adminEmails = (process.env.ADMIN_EMAILS || "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!adminEmails.includes(user.email?.toLowerCase() || "")) {
+    throw new Error("Unauthorized: admin access required");
+  }
+
+  return user;
+}


### PR DESCRIPTION
## Summary

- Add `requireAdmin()` utility to `src/lib/auth.ts` — checks `ADMIN_EMAILS` env var, throws if not admin
- Fix avatar fallback in admin layout (`|| "?"` for edge case without email)

## Why

Server Actions bypass Next.js middleware route guards and can be called directly via POST requests. The middleware protects `/admin/*` page access, but admin Server Actions (coming in #22) need their own auth check. This adds the `requireAdmin()` utility they will use.

## Test plan

- [x] TypeScript strict — no errors
- [x] All 111 unit tests passing
- [x] ESLint — no new warnings

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)