### PR TITLE
feat(admin): add stats dashboard, audit-log, and login-history (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ nul
 # Claude Code local settings (may contain permission-granted secrets)
 .claude/settings.local.json
 
+# Playwright MCP logs
+.playwright-mcp/
+
 # Personal notes
 todo.txt
 

--- a/src/app/(admin)/admin/audit/page.tsx
+++ b/src/app/(admin)/admin/audit/page.tsx
@@ -1,0 +1,170 @@
+import { getAuditEvents, getAuditActionTypes, getAllPractices } from "@/lib/db/queries/admin";
+import { AuditFilters } from "@/components/admin/audit-filters";
+import { AuditDetail } from "@/components/admin/audit-detail";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+type SearchParams = Promise<{
+  action?: string;
+  practiceId?: string;
+  from?: string;
+  to?: string;
+  page?: string;
+}>;
+
+export default async function AdminAuditPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const page = Math.max(1, parseInt(params.page ?? "1", 10));
+
+  const [result, actionTypes, practices] = await Promise.all([
+    getAuditEvents({
+      action: params.action,
+      practiceId: params.practiceId,
+      from: params.from,
+      to: params.to,
+      page,
+      pageSize: 20,
+    }),
+    getAuditActionTypes(),
+    getAllPractices(),
+  ]);
+
+  const totalPages = Math.ceil(result.total / result.pageSize);
+
+  function buildPageUrl(p: number) {
+    const sp = new URLSearchParams();
+    if (params.action) sp.set("action", params.action);
+    if (params.practiceId) sp.set("practiceId", params.practiceId);
+    if (params.from) sp.set("from", params.from);
+    if (params.to) sp.set("to", params.to);
+    sp.set("page", String(p));
+    return `/admin/audit?${sp.toString()}`;
+  }
+
+  const formatDate = (date: Date | null) => {
+    if (!date) return "—";
+    return new Intl.DateTimeFormat("de-DE", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(date));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Audit-Log</h1>
+        <p className="text-muted-foreground">
+          {result.total} {result.total === 1 ? "Eintrag" : "Einträge"} gesamt.
+        </p>
+      </div>
+
+      <AuditFilters
+        actionTypes={actionTypes}
+        practices={practices.map((p) => ({ id: p.id, name: p.name }))}
+      />
+
+      <div className="rounded-lg border bg-white">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Zeitpunkt</TableHead>
+              <TableHead>Aktion</TableHead>
+              <TableHead className="hidden md:table-cell">Praxis</TableHead>
+              <TableHead className="hidden lg:table-cell">Entity</TableHead>
+              <TableHead>Details</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {result.events.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                  Keine Audit-Einträge gefunden.
+                </TableCell>
+              </TableRow>
+            ) : (
+              result.events.map((event) => (
+                <TableRow key={event.id}>
+                  <TableCell className="whitespace-nowrap text-sm">
+                    {formatDate(event.createdAt)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className="font-mono text-xs">
+                      {event.action}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-sm">
+                    {event.practice?.name ?? (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell text-sm">
+                    {event.entity ? (
+                      <span className="font-mono text-xs">
+                        {event.entity}
+                        {event.entityId && (
+                          <span className="text-muted-foreground ml-1">
+                            #{event.entityId.slice(0, 8)}
+                          </span>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <AuditDetail before={event.before} after={event.after} />
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Seite {page} von {totalPages}
+          </p>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Link
+                href={buildPageUrl(page - 1)}
+                className="inline-flex items-center gap-1 rounded-md border px-3 py-2 text-sm hover:bg-gray-50"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Zurück
+              </Link>
+            )}
+            {page < totalPages && (
+              <Link
+                href={buildPageUrl(page + 1)}
+                className="inline-flex items-center gap-1 rounded-md border px-3 py-2 text-sm hover:bg-gray-50"
+              >
+                Weiter
+                <ChevronRight className="h-4 w-4" />
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/logins/page.tsx
+++ b/src/app/(admin)/admin/logins/page.tsx
@@ -1,0 +1,166 @@
+import { getLoginEvents, getAllPractices } from "@/lib/db/queries/admin";
+import { LoginFilters } from "@/components/admin/login-filters";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+type SearchParams = Promise<{
+  practiceId?: string;
+  from?: string;
+  to?: string;
+  page?: string;
+}>;
+
+export default async function AdminLoginsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const page = Math.max(1, parseInt(params.page ?? "1", 10));
+
+  const [result, practices] = await Promise.all([
+    getLoginEvents({
+      practiceId: params.practiceId,
+      from: params.from,
+      to: params.to,
+      page,
+      pageSize: 20,
+    }),
+    getAllPractices(),
+  ]);
+
+  const totalPages = Math.ceil(result.total / result.pageSize);
+
+  function buildPageUrl(p: number) {
+    const sp = new URLSearchParams();
+    if (params.practiceId) sp.set("practiceId", params.practiceId);
+    if (params.from) sp.set("from", params.from);
+    if (params.to) sp.set("to", params.to);
+    sp.set("page", String(p));
+    return `/admin/logins?${sp.toString()}`;
+  }
+
+  const formatDate = (date: Date | null) => {
+    if (!date) return "—";
+    return new Intl.DateTimeFormat("de-DE", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(date));
+  };
+
+  const parseUserAgent = (ua: string | null) => {
+    if (!ua) return "Unbekannt";
+    if (ua.includes("Mobile")) return "Mobil";
+    if (ua.includes("Chrome")) return "Chrome";
+    if (ua.includes("Firefox")) return "Firefox";
+    if (ua.includes("Safari")) return "Safari";
+    if (ua.includes("Edge")) return "Edge";
+    return ua.slice(0, 30);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Login-History</h1>
+        <p className="text-muted-foreground">
+          {result.total} {result.total === 1 ? "Login" : "Logins"} gesamt.
+        </p>
+      </div>
+
+      <LoginFilters
+        practices={practices.map((p) => ({ id: p.id, name: p.name }))}
+      />
+
+      <div className="rounded-lg border bg-white">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Zeitpunkt</TableHead>
+              <TableHead>Praxis</TableHead>
+              <TableHead className="hidden md:table-cell">Methode</TableHead>
+              <TableHead className="hidden lg:table-cell">Browser</TableHead>
+              <TableHead className="hidden lg:table-cell">IP</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {result.events.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                  Keine Login-Einträge gefunden.
+                </TableCell>
+              </TableRow>
+            ) : (
+              result.events.map((event) => (
+                <TableRow key={event.id}>
+                  <TableCell className="whitespace-nowrap text-sm">
+                    {formatDate(event.createdAt)}
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    <div>
+                      <p className="font-medium">{event.practice?.name ?? "—"}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {event.practice?.email ?? ""}
+                      </p>
+                    </div>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    <Badge variant="outline" className="text-xs">
+                      {event.method ?? "password"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
+                    {parseUserAgent(event.userAgent)}
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell text-sm font-mono text-muted-foreground">
+                    {event.ipAddress ?? "—"}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Seite {page} von {totalPages}
+          </p>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Link
+                href={buildPageUrl(page - 1)}
+                className="inline-flex items-center gap-1 rounded-md border px-3 py-2 text-sm hover:bg-gray-50"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Zurück
+              </Link>
+            )}
+            {page < totalPages && (
+              <Link
+                href={buildPageUrl(page + 1)}
+                className="inline-flex items-center gap-1 rounded-md border px-3 py-2 text-sm hover:bg-gray-50"
+              >
+                Weiter
+                <ChevronRight className="h-4 w-4" />
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,5 +1,32 @@
-import { Building2, BarChart3, Shield } from "lucide-react";
+import { Building2, BarChart3, ScrollText, LogIn, Shield } from "lucide-react";
 import Link from "next/link";
+
+const adminLinks = [
+  {
+    href: "/admin/practices",
+    icon: Building2,
+    title: "Praxen",
+    description: "Alle Praxen verwalten, Plans überschreiben.",
+  },
+  {
+    href: "/admin/stats",
+    icon: BarChart3,
+    title: "Statistiken",
+    description: "Plattform-Metriken, Plan-Verteilung, Trends.",
+  },
+  {
+    href: "/admin/audit",
+    icon: ScrollText,
+    title: "Audit-Log",
+    description: "Änderungen nachverfolgen, Before/After einsehen.",
+  },
+  {
+    href: "/admin/logins",
+    icon: LogIn,
+    title: "Login-History",
+    description: "Login-Events, IP-Adressen, Browser.",
+  },
+];
 
 export default function AdminPage() {
   return (
@@ -11,28 +38,18 @@ export default function AdminPage() {
         </p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <Link
-          href="/admin/practices"
-          className="rounded-lg border bg-white p-6 shadow-sm hover:shadow-md transition-shadow"
-        >
-          <Building2 className="h-8 w-8 text-primary mb-3" />
-          <h2 className="font-semibold">Praxen</h2>
-          <p className="text-sm text-muted-foreground">
-            Alle Praxen verwalten, Plans überschreiben.
-          </p>
-        </Link>
-
-        <Link
-          href="/admin/stats"
-          className="rounded-lg border bg-white p-6 shadow-sm hover:shadow-md transition-shadow"
-        >
-          <BarChart3 className="h-8 w-8 text-primary mb-3" />
-          <h2 className="font-semibold">Statistiken</h2>
-          <p className="text-sm text-muted-foreground">
-            Plattform-Metriken, Audit-Logs, Login-Events.
-          </p>
-        </Link>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {adminLinks.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="rounded-lg border bg-white p-6 shadow-sm hover:shadow-md transition-shadow"
+          >
+            <link.icon className="h-8 w-8 text-primary mb-3" />
+            <h2 className="font-semibold">{link.title}</h2>
+            <p className="text-sm text-muted-foreground">{link.description}</p>
+          </Link>
+        ))}
 
         <div className="rounded-lg border bg-white p-6 shadow-sm opacity-60">
           <Shield className="h-8 w-8 text-muted-foreground mb-3" />

--- a/src/app/(admin)/admin/stats/page.tsx
+++ b/src/app/(admin)/admin/stats/page.tsx
@@ -1,8 +1,35 @@
-import { getPlatformStats } from "@/lib/db/queries/admin";
-import { BarChart3 } from "lucide-react";
+import { getPlatformStats, getExtendedPlatformStats } from "@/lib/db/queries/admin";
+import { PlanDistributionChart } from "@/components/admin/plan-distribution-chart";
+import { RegistrationsChart } from "@/components/admin/registrations-chart";
+import {
+  Building2,
+  MessageSquare,
+  Globe,
+  TrendingUp,
+  BarChart3,
+  Shield,
+} from "lucide-react";
 
 export default async function AdminStatsPage() {
-  const stats = await getPlatformStats();
+  const [stats, extended] = await Promise.all([
+    getPlatformStats(),
+    getExtendedPlatformStats(),
+  ]);
+
+  const planData = [
+    { name: "Free", count: stats.freePlan, color: "#94a3b8" },
+    { name: "Starter", count: stats.starterPlan, color: "#3b82f6" },
+    { name: "Professional", count: stats.professionalPlan, color: "#8b5cf6" },
+  ];
+
+  const registrationData = extended.registrations.map((r) => {
+    const d = new Date(r.date);
+    return {
+      date: r.date,
+      count: r.count,
+      label: `${d.getDate().toString().padStart(2, "0")}.${(d.getMonth() + 1).toString().padStart(2, "0")}.`,
+    };
+  });
 
   return (
     <div className="space-y-6">
@@ -13,33 +40,81 @@ export default async function AdminStatsPage() {
         </p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-4">
+      {/* Key Metrics */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <div className="rounded-lg border bg-white p-6">
-          <p className="text-sm text-muted-foreground">Praxen gesamt</p>
+          <div className="flex items-center gap-2 mb-2">
+            <Building2 className="h-4 w-4 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Praxen gesamt</p>
+          </div>
           <p className="text-3xl font-bold">{stats.totalPractices}</p>
         </div>
         <div className="rounded-lg border bg-white p-6">
-          <p className="text-sm text-muted-foreground">Free</p>
-          <p className="text-3xl font-bold">{stats.freePlan}</p>
+          <div className="flex items-center gap-2 mb-2">
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Antworten (30 Tage)</p>
+          </div>
+          <p className="text-3xl font-bold">{extended.responses30d}</p>
         </div>
         <div className="rounded-lg border bg-white p-6">
-          <p className="text-sm text-muted-foreground">Starter</p>
-          <p className="text-3xl font-bold">{stats.starterPlan}</p>
+          <div className="flex items-center gap-2 mb-2">
+            <Globe className="h-4 w-4 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Google verbunden</p>
+          </div>
+          <p className="text-3xl font-bold">{extended.googleRate}%</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {extended.withGoogle} von {extended.totalPractices} Praxen
+          </p>
         </div>
         <div className="rounded-lg border bg-white p-6">
-          <p className="text-sm text-muted-foreground">Professional</p>
-          <p className="text-3xl font-bold">{stats.professionalPlan}</p>
+          <div className="flex items-center gap-2 mb-2">
+            <Shield className="h-4 w-4 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Aktive Overrides</p>
+          </div>
+          <p className="text-3xl font-bold">{stats.withOverride}</p>
         </div>
       </div>
 
-      <div className="rounded-lg border bg-white p-6">
-        <div className="flex items-center gap-2 mb-4">
-          <BarChart3 className="h-5 w-5 text-muted-foreground" />
-          <h2 className="font-semibold">Overrides</h2>
+      {/* Charts */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="rounded-lg border bg-white p-6">
+          <div className="flex items-center gap-2 mb-4">
+            <BarChart3 className="h-5 w-5 text-muted-foreground" />
+            <h2 className="font-semibold">Plan-Verteilung</h2>
+          </div>
+          <PlanDistributionChart data={planData} />
         </div>
-        <p className="text-sm text-muted-foreground">
-          {stats.withOverride} Praxen haben aktuell einen aktiven Plan-Override.
-        </p>
+
+        <div className="rounded-lg border bg-white p-6">
+          <div className="flex items-center gap-2 mb-4">
+            <TrendingUp className="h-5 w-5 text-muted-foreground" />
+            <h2 className="font-semibold">Registrierungen (30 Tage)</h2>
+          </div>
+          <RegistrationsChart data={registrationData} />
+        </div>
+      </div>
+
+      {/* Plan breakdown */}
+      <div className="rounded-lg border bg-white p-6">
+        <h2 className="font-semibold mb-4">Plan-Details</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {planData.map((plan) => (
+            <div key={plan.name} className="flex items-center justify-between rounded-md border px-4 py-3">
+              <div className="flex items-center gap-3">
+                <div
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: plan.color }}
+                />
+                <span className="text-sm font-medium">{plan.name}</span>
+              </div>
+              <span className="text-sm text-muted-foreground">
+                {plan.count} ({stats.totalPractices > 0
+                  ? Math.round((plan.count / stats.totalPractices) * 100)
+                  : 0}%)
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/admin/admin-nav.tsx
+++ b/src/components/admin/admin-nav.tsx
@@ -3,12 +3,14 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { LayoutDashboard, Building2, BarChart3 } from "lucide-react";
+import { LayoutDashboard, Building2, BarChart3, ScrollText, LogIn } from "lucide-react";
 
 const navItems = [
   { href: "/admin", label: "Übersicht", icon: LayoutDashboard, exact: true },
   { href: "/admin/practices", label: "Praxen", icon: Building2, exact: false },
-  { href: "/admin/stats", label: "Statistiken", icon: BarChart3, exact: false },
+  { href: "/admin/stats", label: "Statistiken", icon: BarChart3, exact: true },
+  { href: "/admin/audit", label: "Audit-Log", icon: ScrollText, exact: false },
+  { href: "/admin/logins", label: "Logins", icon: LogIn, exact: false },
 ];
 
 export function AdminNav() {

--- a/src/components/admin/audit-detail.tsx
+++ b/src/components/admin/audit-detail.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+export function AuditDetail({
+  before,
+  after,
+}: {
+  before: unknown;
+  after: unknown;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (!before && !after) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800"
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        {open ? "Zuklappen" : "Details"}
+      </button>
+      {open && (
+        <div className="mt-2 space-y-2">
+          {before != null && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-1">Vorher:</p>
+              <pre className="max-h-40 overflow-auto rounded bg-slate-50 p-2 text-xs">
+                {JSON.stringify(before, null, 2)}
+              </pre>
+            </div>
+          )}
+          {after != null && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-1">Nachher:</p>
+              <pre className="max-h-40 overflow-auto rounded bg-slate-50 p-2 text-xs">
+                {JSON.stringify(after, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/audit-filters.tsx
+++ b/src/components/admin/audit-filters.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useTransition } from "react";
+
+export function AuditFilters({
+  actionTypes,
+  practices,
+}: {
+  actionTypes: string[];
+  practices: { id: string; name: string }[];
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const updateParams = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      params.delete("page");
+      startTransition(() => {
+        router.push(`/admin/audit?${params.toString()}`);
+      });
+    },
+    [router, searchParams, startTransition]
+  );
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <select
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("action") ?? ""}
+        onChange={(e) => updateParams("action", e.target.value)}
+        disabled={isPending}
+      >
+        <option value="">Alle Aktionen</option>
+        {actionTypes.map((action) => (
+          <option key={action} value={action}>
+            {action}
+          </option>
+        ))}
+      </select>
+
+      <select
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("practiceId") ?? ""}
+        onChange={(e) => updateParams("practiceId", e.target.value)}
+        disabled={isPending}
+      >
+        <option value="">Alle Praxen</option>
+        {practices.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="date"
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("from") ?? ""}
+        onChange={(e) => updateParams("from", e.target.value)}
+        disabled={isPending}
+        placeholder="Von"
+      />
+
+      <input
+        type="date"
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("to") ?? ""}
+        onChange={(e) => updateParams("to", e.target.value)}
+        disabled={isPending}
+        placeholder="Bis"
+      />
+
+      {isPending && (
+        <span className="text-xs text-muted-foreground">Laden...</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/login-filters.tsx
+++ b/src/components/admin/login-filters.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useTransition } from "react";
+
+export function LoginFilters({
+  practices,
+}: {
+  practices: { id: string; name: string }[];
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const updateParams = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      params.delete("page");
+      startTransition(() => {
+        router.push(`/admin/logins?${params.toString()}`);
+      });
+    },
+    [router, searchParams, startTransition]
+  );
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <select
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("practiceId") ?? ""}
+        onChange={(e) => updateParams("practiceId", e.target.value)}
+        disabled={isPending}
+      >
+        <option value="">Alle Praxen</option>
+        {practices.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="date"
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("from") ?? ""}
+        onChange={(e) => updateParams("from", e.target.value)}
+        disabled={isPending}
+        placeholder="Von"
+      />
+
+      <input
+        type="date"
+        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        value={searchParams.get("to") ?? ""}
+        onChange={(e) => updateParams("to", e.target.value)}
+        disabled={isPending}
+        placeholder="Bis"
+      />
+
+      {isPending && (
+        <span className="text-xs text-muted-foreground">Laden...</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/plan-distribution-chart.tsx
+++ b/src/components/admin/plan-distribution-chart.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { memo } from "react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from "recharts";
+
+type PlanData = {
+  name: string;
+  count: number;
+  color: string;
+};
+
+const PLAN_COLORS: Record<string, string> = {
+  Free: "#94a3b8",
+  Starter: "#3b82f6",
+  Professional: "#8b5cf6",
+};
+
+export const PlanDistributionChart = memo(function PlanDistributionChart({
+  data,
+}: {
+  data: PlanData[];
+}) {
+  if (data.every((d) => d.count === 0)) {
+    return (
+      <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+        Noch keine Praxen registriert.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: -10 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+        <XAxis dataKey="name" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+        <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={false} allowDecimals={false} />
+        <Tooltip
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const item = payload[0]?.payload as PlanData;
+            return (
+              <div className="rounded-md border bg-white px-3 py-2 text-sm shadow-md">
+                <p className="font-medium">{item.name}</p>
+                <p style={{ color: item.color }}>
+                  {item.count} {item.count === 1 ? "Praxis" : "Praxen"}
+                </p>
+              </div>
+            );
+          }}
+        />
+        <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={PLAN_COLORS[entry.name] ?? "#94a3b8"} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+});

--- a/src/components/admin/registrations-chart.tsx
+++ b/src/components/admin/registrations-chart.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { memo } from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+
+type RegistrationPoint = {
+  date: string;
+  count: number;
+  label: string;
+};
+
+export const RegistrationsChart = memo(function RegistrationsChart({
+  data,
+}: {
+  data: RegistrationPoint[];
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+        Keine Registrierungen in den letzten 30 Tagen.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <AreaChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: -10 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+        <XAxis dataKey="label" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+        <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={false} allowDecimals={false} />
+        <Tooltip
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const point = payload[0]?.payload as RegistrationPoint;
+            return (
+              <div className="rounded-md border bg-white px-3 py-2 text-sm shadow-md">
+                <p className="font-medium">{point.date}</p>
+                <p className="text-emerald-600">
+                  {point.count} {point.count === 1 ? "Registrierung" : "Registrierungen"}
+                </p>
+              </div>
+            );
+          }}
+        />
+        <Area
+          type="monotone"
+          dataKey="count"
+          stroke="#10b981"
+          fill="#10b981"
+          fillOpacity={0.1}
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+});


### PR DESCRIPTION
## Was

Erweitert das Admin-Panel um vollständiges Stats-Dashboard, Audit-Log Viewer und Login-History.

### Stats Dashboard (`/admin/stats`)
- Key Metrics: Praxen gesamt, Antworten (30d), Google-Verbindungsrate, aktive Overrides
- Plan-Verteilung als Recharts BarChart
- Registrierungs-Trend (30 Tage) als Recharts AreaChart
- Plan-Details mit Prozentanteilen

### Audit-Log (`/admin/audit`)
- Tabelle mit allen Audit-Events (practice.updated, admin.override.set, etc.)
- Filter: Aktion, Praxis, Zeitraum (von/bis)
- Expandierbare Before/After JSON-Ansicht
- Pagination (20 pro Seite)

### Login-History (`/admin/logins`)
- Tabelle mit allen Login-Events
- Filter: Praxis, Zeitraum
- Browser-Erkennung (Chrome, Mobile, etc.) und IP-Anzeige
- Pagination (20 pro Seite)

### Weitere Änderungen
- Admin-Navigation um Audit-Log und Logins erweitert (5 Items)
- Admin-Dashboard Startseite mit Links zu allen Bereichen
- DB-Queries für Audit- und Login-Events mit Filtern und Pagination
- `.playwright-mcp/` zu `.gitignore` hinzugefügt

Closes #23

## Checkliste

- [x] Build sauber
- [x] Tests grün (111/111)
- [x] TypeCheck OK
- [x] Lint OK (keine Errors)
- [x] Browser-verifiziert (lokal): Stats, Audit, Logins