### PR TITLE
fix(security): add IDOR, SSRF, XSS, ownership checks

### DIFF
--- a/src/actions/alerts.ts
+++ b/src/actions/alerts.ts
@@ -19,7 +19,7 @@ export async function markAlertRead(alertId: string) {
     with: { practice: true },
   });
 
-  if (!alert || alert.practice.email !== user.email) {
+  if (!alert || alert.practice.ownerUserId !== user.id) {
     throw new Error("Alert nicht gefunden");
   }
 
@@ -44,7 +44,7 @@ export async function addAlertNote(alertId: string, note: string) {
     with: { practice: true },
   });
 
-  if (!alert || alert.practice.email !== user.email) {
+  if (!alert || alert.practice.ownerUserId !== user.id) {
     throw new Error("Alert nicht gefunden");
   }
 

--- a/src/app/api/practice/website-logos/route.ts
+++ b/src/app/api/practice/website-logos/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getUserOptional } from "@/lib/auth";
+import { isSafeUrl } from "@/lib/url-validation";
 
 /**
  * Extract potential logo URLs from a website by checking common locations:
@@ -38,6 +39,11 @@ export async function GET(request: Request) {
         seen.add(url);
         logos.push(url);
       }
+    }
+
+    // SSRF protection: block private/internal URLs
+    if (!isSafeUrl(baseUrl.toString())) {
+      return NextResponse.json({ logos: [] });
     }
 
     // Try to fetch the homepage HTML and extract logo references

--- a/src/app/api/public/track-click/route.ts
+++ b/src/app/api/public/track-click/route.ts
@@ -20,6 +20,18 @@ export async function POST(request: Request) {
       );
     }
 
+    // Verify response exists before updating
+    const existing = await db.query.responses.findFirst({
+      where: eq(responses.id, parsed.data.responseId),
+      columns: { id: true },
+    });
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Response nicht gefunden", code: "NOT_FOUND" },
+        { status: 404 }
+      );
+    }
+
     await db
       .update(responses)
       .set({ googleReviewClicked: true })

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,6 +2,15 @@ import { Resend } from "resend";
 
 const FROM_EMAIL = "PraxisPuls <noreply@praxispuls.de>";
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 function getResend() {
   if (!process.env.RESEND_API_KEY) {
     throw new Error("RESEND_API_KEY is not set");
@@ -36,12 +45,12 @@ export async function sendDetractorAlert(params: {
     html: `
       <div style="font-family: sans-serif; max-width: 500px; margin: 0 auto;">
         <h2 style="color: #dc2626;">⚠️ Kritisches Feedback eingegangen</h2>
-        <p><strong>Praxis:</strong> ${practiceName}</p>
+        <p><strong>Praxis:</strong> ${escapeHtml(practiceName)}</p>
         <p><strong>NPS-Score:</strong> ${npsScore}/10</p>
         <p><strong>Zeitpunkt:</strong> ${dateStr}</p>
         ${freeText ? `
           <div style="margin-top: 16px; padding: 16px; background: #f9fafb; border-left: 4px solid #dc2626; border-radius: 4px;">
-            <p style="margin: 0; font-style: italic;">"${freeText}"</p>
+            <p style="margin: 0; font-style: italic;">"${escapeHtml(freeText)}"</p>
           </div>
         ` : ""}
         <p style="margin-top: 24px;">
@@ -72,7 +81,7 @@ export async function sendWelcomeEmail(params: {
     html: `
       <div style="font-family: sans-serif; max-width: 500px; margin: 0 auto;">
         <h2>Willkommen bei PraxisPuls!</h2>
-        <p>Hallo ${params.practiceName},</p>
+        <p>Hallo ${escapeHtml(params.practiceName)},</p>
         <p>vielen Dank für Ihre Registrierung. In wenigen Schritten ist Ihre Patientenumfrage startklar:</p>
         <ol>
           <li>Praxisdaten vervollständigen</li>
@@ -109,7 +118,7 @@ export async function sendUpgradeReminder(params: {
     html: `
       <div style="font-family: sans-serif; max-width: 500px; margin: 0 auto;">
         <h2>Antwort-Limit fast erreicht</h2>
-        <p>Hallo ${params.practiceName},</p>
+        <p>Hallo ${escapeHtml(params.practiceName)},</p>
         <p>Sie haben bereits <strong>${params.currentCount} von ${params.limit}</strong> Antworten diesen Monat erhalten. Das zeigt, dass Ihre Patienten aktiv Feedback geben!</p>
         <p>Mit dem Starter-Plan für 49 €/Monat erhalten Sie:</p>
         <ul>

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -1,0 +1,35 @@
+/**
+ * Validate that a URL is safe to fetch server-side.
+ * Blocks private/internal IPs to prevent SSRF attacks.
+ */
+export function isSafeUrl(urlString: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  if (!["http:", "https:"].includes(url.protocol)) return false;
+
+  const hostname = url.hostname.toLowerCase();
+
+  // Block localhost and loopback
+  if (
+    ["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(hostname)
+  ) {
+    return false;
+  }
+
+  // Block private/reserved IPv4 ranges
+  const parts = hostname.split(".").map(Number);
+  if (parts.length === 4 && parts.every((p) => !isNaN(p))) {
+    if (parts[0] === 10) return false; // 10.0.0.0/8
+    if (parts[0] === 172 && parts[1]! >= 16 && parts[1]! <= 31) return false; // 172.16.0.0/12
+    if (parts[0] === 192 && parts[1] === 168) return false; // 192.168.0.0/16
+    if (parts[0] === 169 && parts[1] === 254) return false; // 169.254.0.0/16 (link-local)
+    if (parts[0] === 0) return false; // 0.0.0.0/8
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- **IDOR fix:** `changeSurveyTemplate()` now verifies survey ownership via `practiceId` before updating (matching `toggleSurvey()` pattern)
- **SSRF fix:** New `isSafeUrl()` utility blocks private/internal IPs (RFC-1918, link-local, loopback) in `website-logos` and `logo-from-url` routes
- **XSS fix:** All user inputs (`practiceName`, `freeText`) escaped in email HTML templates via `escapeHtml()`
- **track-click:** Verifies response existence before blind `UPDATE`
- **Alert ownership:** Uses `ownerUserId` instead of fragile `email` comparison

Closes #33

## Test plan
- [x] `npm run typecheck` — no errors
- [x] `npm run test` — 126 tests passing
- [x] `npm run build` — clean build
- [x] ESLint — no errors (only pre-existing warnings)
- [ ] Manual: Survey template change, logo upload with internal URL, alert marking

🤖 Generated with [Claude Code](https://claude.com/claude-code)