### PR TITLE
refactor(api): add requireAuthForApi() helper and standardize error codes

### DIFF
--- a/src/app/api/auth/login-event/route.ts
+++ b/src/app/api/auth/login-event/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getUserOptional } from "@/lib/auth";
+import { requireAuthForApi } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { loginEvents } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
@@ -11,14 +11,13 @@ import { getActivePracticeForUser } from "@/lib/practice";
  */
 export async function POST(request: Request) {
   try {
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
+    const user = auth.user;
 
     const practice = await getActivePracticeForUser(user.id);
     if (!practice) {
-      return NextResponse.json({ error: "Praxis nicht gefunden" }, { status: 404 });
+      return NextResponse.json({ error: "Praxis nicht gefunden", code: "NOT_FOUND" }, { status: 404 });
     }
 
     const body = await request.json().catch(() => ({}));
@@ -38,7 +37,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true });
   } catch {
-    return NextResponse.json({ error: "Interner Fehler" }, { status: 500 });
+    return NextResponse.json({ error: "Interner Fehler", code: "INTERNAL_ERROR" }, { status: 500 });
   }
 }
 
@@ -47,10 +46,9 @@ export async function POST(request: Request) {
  */
 export async function GET() {
   try {
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
+    const user = auth.user;
 
     const practice = await getActivePracticeForUser(user.id);
     if (!practice) {

--- a/src/app/api/billing/invoices/route.ts
+++ b/src/app/api/billing/invoices/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
-import { getUserOptional } from "@/lib/auth";
+import { requireAuthForApi } from "@/lib/auth";
 import { stripe } from "@/lib/stripe";
 import { getActivePracticeForUser } from "@/lib/practice";
 
 export async function GET() {
   try {
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
+    const user = auth.user;
 
     const practice = await getActivePracticeForUser(user.id);
     if (!practice?.stripeCustomerId) {
@@ -34,6 +33,6 @@ export async function GET() {
     return NextResponse.json({ invoices: formatted });
   } catch (err) {
     console.error("Invoices error:", err);
-    return NextResponse.json({ error: "Fehler" }, { status: 500 });
+    return NextResponse.json({ error: "Fehler", code: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/google/photo/route.ts
+++ b/src/app/api/google/photo/route.ts
@@ -1,29 +1,27 @@
 import { NextResponse } from "next/server";
-import { getUserOptional } from "@/lib/auth";
+import { requireAuthForApi } from "@/lib/auth";
 import { getPlacePhotoUrl } from "@/lib/google";
 
 export async function GET(request: Request) {
   try {
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
 
     const { searchParams } = new URL(request.url);
     const ref = searchParams.get("ref");
     if (!ref) {
-      return NextResponse.json({ error: "Missing ref parameter" }, { status: 400 });
+      return NextResponse.json({ error: "Missing ref parameter", code: "BAD_REQUEST" }, { status: 400 });
     }
 
     const photoUrl = getPlacePhotoUrl(ref, 400);
     if (!photoUrl) {
-      return NextResponse.json({ error: "Google API not configured" }, { status: 500 });
+      return NextResponse.json({ error: "Google API not configured", code: "INTERNAL_ERROR" }, { status: 500 });
     }
 
     // Proxy the photo from Google
     const res = await fetch(photoUrl);
     if (!res.ok) {
-      return NextResponse.json({ error: "Photo not found" }, { status: 404 });
+      return NextResponse.json({ error: "Photo not found", code: "NOT_FOUND" }, { status: 404 });
     }
 
     const contentType = res.headers.get("content-type") || "image/jpeg";
@@ -36,6 +34,6 @@ export async function GET(request: Request) {
       },
     });
   } catch {
-    return NextResponse.json({ error: "Interner Fehler" }, { status: 500 });
+    return NextResponse.json({ error: "Interner Fehler", code: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/practice/[id]/route.ts
+++ b/src/app/api/practice/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getUserOptional } from "@/lib/auth";
+import { requireAuthForApi } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { practices } from "@/lib/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
@@ -11,10 +11,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
+    const user = auth.user;
 
     const { id } = await params;
 
@@ -30,7 +29,7 @@ export async function DELETE(
 
     if (!practice) {
       return NextResponse.json(
-        { error: "Standort nicht gefunden oder kein Zugriff" },
+        { error: "Standort nicht gefunden oder kein Zugriff", code: "NOT_FOUND" },
         { status: 404 }
       );
     }
@@ -69,7 +68,7 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch {
     return NextResponse.json(
-      { error: "Fehler beim Entfernen" },
+      { error: "Fehler beim Entfernen", code: "INTERNAL_ERROR" },
       { status: 500 }
     );
   }

--- a/src/app/api/practice/logo/route.ts
+++ b/src/app/api/practice/logo/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
-import { getUserOptional } from "@/lib/auth";
+import { requireAuthForApi } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { practices } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -46,10 +46,9 @@ function extractStoragePath(publicUrl: string): string | null {
 export async function POST(request: Request) {
   try {
     // 1. Auth check
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet", code: "UNAUTHORIZED" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
+    const user = auth.user;
 
     // 2. Find the active practice for this user
     const practice = await getActivePracticeForUser(user.id);

--- a/src/app/api/practice/website-logos/route.ts
+++ b/src/app/api/practice/website-logos/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getUserOptional } from "@/lib/auth";
+import { requireAuthForApi } from "@/lib/auth";
 import { isSafeUrl } from "@/lib/url-validation";
 
 /**
@@ -12,15 +12,13 @@ import { isSafeUrl } from "@/lib/url-validation";
  */
 export async function GET(request: Request) {
   try {
-    const user = await getUserOptional();
-    if (!user) {
-      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
-    }
+    const auth = await requireAuthForApi();
+    if (auth.error) return auth.error;
 
     const { searchParams } = new URL(request.url);
     const websiteUrl = searchParams.get("url");
     if (!websiteUrl) {
-      return NextResponse.json({ error: "Missing url parameter" }, { status: 400 });
+      return NextResponse.json({ error: "Missing url parameter", code: "BAD_REQUEST" }, { status: 400 });
     }
 
     // Normalize URL

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: Request) {
 
   if (!signature || !process.env.STRIPE_WEBHOOK_SECRET) {
     return NextResponse.json(
-      { error: "Missing signature or webhook secret" },
+      { error: "Missing signature or webhook secret", code: "BAD_REQUEST" },
       { status: 400 }
     );
   }
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error(`Webhook signature verification failed: ${message}`);
     return NextResponse.json(
-      { error: "Invalid signature" },
+      { error: "Invalid signature", code: "BAD_REQUEST" },
       { status: 400 }
     );
   }
@@ -76,7 +76,7 @@ export async function POST(request: Request) {
   } catch (err) {
     console.error(`Webhook handler error for ${event.type}:`, err);
     return NextResponse.json(
-      { error: "Webhook handler failed" },
+      { error: "Webhook handler failed", code: "INTERNAL_ERROR" },
       { status: 500 }
     );
   }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { NextResponse } from "next/server";
+import type { User } from "@supabase/supabase-js";
 
 /**
  * Get the current authenticated user or redirect to login.
@@ -29,6 +31,26 @@ export async function getUserOptional() {
     data: { user },
   } = await supabase.auth.getUser();
   return user;
+}
+
+/**
+ * Require authentication for API routes.
+ * Returns a discriminated union: either { user } or { error } (NextResponse).
+ */
+export async function requireAuthForApi(): Promise<
+  | { user: User; error?: never }
+  | { user?: never; error: NextResponse }
+> {
+  const user = await getUserOptional();
+  if (!user) {
+    return {
+      error: NextResponse.json(
+        { error: "Nicht angemeldet", code: "UNAUTHORIZED" },
+        { status: 401 }
+      ),
+    };
+  }
+  return { user };
 }
 
 /**


### PR DESCRIPTION
## Summary
- **New `requireAuthForApi()` helper** in `lib/auth.ts` with discriminated union return type for type-safe auth in API routes
- **13 API routes refactored** to use centralized auth helper (eliminates duplicated 3-line auth pattern)
- **All error responses standardized** with `code` field: `UNAUTHORIZED`, `BAD_REQUEST`, `NOT_FOUND`, `FORBIDDEN`, `INTERNAL_ERROR`
- **Stripe webhook** error responses also standardized

Closes #35

## Test plan
- [x] `npm run typecheck` — no errors
- [x] `npm run test` — 126 tests passing
- [x] `npm run build` — clean build
- [x] Grep confirms: zero API error responses without `code` field
- [ ] Manual: auth flows, billing, Google Places, logo upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)