### PR TITLE
chore: fix knip config hints + unexport getUserOptional

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,9 +8,6 @@
     "src/components/ui/**"
   ],
   "ignoreDependencies": [
-    "eslint-config-next",
-    "simple-git-hooks",
-    "lint-staged",
-    "@vitest/coverage-v8"
+    "eslint-config-next"
   ]
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,7 +25,7 @@ export async function getUser() {
  * Get the current user without redirecting.
  * Returns null if not authenticated.
  */
-export async function getUserOptional() {
+async function getUserOptional() {
   const supabase = await createClient();
   const {
     data: { user },


### PR DESCRIPTION
## Summary
- Remove 3 stale entries from `knip.json` `ignoreDependencies` (knip detects them natively)
- Make `getUserOptional()` module-private — only used internally by `requireAuthForApi()`

**Knip results improved:**
- Configuration hints: 3 → 0
- Unused exports: 3 → 2

Closes #41

## Test plan
- [x] `npm run typecheck` — no errors
- [x] `npm run test` — 126 tests passing
- [x] `npm run knip` — config hints resolved, getUserOptional gone from unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)