### PR TITLE
test: add coverage for new files, fix IPv6 loopback check

### DIFF
--- a/src/lib/__tests__/constants-plans.test.ts
+++ b/src/lib/__tests__/constants-plans.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { PLAN_BADGE_STYLES, PLAN_LABELS } from "../constants/plans";
+
+describe("PLAN_BADGE_STYLES", () => {
+  it("has styles for all plan tiers", () => {
+    expect(PLAN_BADGE_STYLES).toHaveProperty("free");
+    expect(PLAN_BADGE_STYLES).toHaveProperty("starter");
+    expect(PLAN_BADGE_STYLES).toHaveProperty("professional");
+  });
+
+  it("contains Tailwind class strings", () => {
+    expect(PLAN_BADGE_STYLES.free).toContain("bg-");
+    expect(PLAN_BADGE_STYLES.starter).toContain("bg-");
+    expect(PLAN_BADGE_STYLES.professional).toContain("bg-");
+  });
+});
+
+describe("PLAN_LABELS", () => {
+  it("has labels for all plan tiers", () => {
+    expect(PLAN_LABELS.free).toBe("Free");
+    expect(PLAN_LABELS.starter).toBe("Starter");
+    expect(PLAN_LABELS.professional).toBe("Professional");
+  });
+});

--- a/src/lib/__tests__/survey-templates.test.ts
+++ b/src/lib/__tests__/survey-templates.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { SURVEY_TEMPLATES } from "../survey-templates";
+
+describe("SURVEY_TEMPLATES", () => {
+  it("has 3 templates", () => {
+    expect(SURVEY_TEMPLATES).toHaveLength(3);
+  });
+
+  it("all templates have required fields", () => {
+    for (const template of SURVEY_TEMPLATES) {
+      expect(template.id).toBeTruthy();
+      expect(template.name).toBeTruthy();
+      expect(template.description).toBeTruthy();
+      expect(template.questions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all templates start with an NPS question", () => {
+    for (const template of SURVEY_TEMPLATES) {
+      expect(template.questions[0]!.type).toBe("nps");
+      expect(template.questions[0]!.required).toBe(true);
+    }
+  });
+
+  it("includes standard, kurz, and prophylaxe", () => {
+    const ids = SURVEY_TEMPLATES.map((t) => t.id);
+    expect(ids).toContain("zahnarzt_standard");
+    expect(ids).toContain("zahnarzt_kurz");
+    expect(ids).toContain("zahnarzt_prophylaxe");
+  });
+});

--- a/src/lib/__tests__/url-validation.test.ts
+++ b/src/lib/__tests__/url-validation.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { isSafeUrl } from "../url-validation";
+
+describe("isSafeUrl", () => {
+  describe("valid public URLs", () => {
+    it("allows https URLs", () => {
+      expect(isSafeUrl("https://example.com")).toBe(true);
+    });
+
+    it("allows http URLs", () => {
+      expect(isSafeUrl("http://example.com")).toBe(true);
+    });
+
+    it("allows URLs with paths", () => {
+      expect(isSafeUrl("https://example.com/logo.png")).toBe(true);
+    });
+
+    it("allows public IP addresses", () => {
+      expect(isSafeUrl("http://8.8.8.8")).toBe(true);
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("rejects malformed URLs", () => {
+      expect(isSafeUrl("not-a-url")).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      expect(isSafeUrl("")).toBe(false);
+    });
+  });
+
+  describe("blocked protocols", () => {
+    it("rejects ftp://", () => {
+      expect(isSafeUrl("ftp://example.com")).toBe(false);
+    });
+
+    it("rejects file://", () => {
+      expect(isSafeUrl("file:///etc/passwd")).toBe(false);
+    });
+  });
+
+  describe("localhost and loopback", () => {
+    it("rejects localhost", () => {
+      expect(isSafeUrl("http://localhost")).toBe(false);
+    });
+
+    it("rejects 127.0.0.1", () => {
+      expect(isSafeUrl("http://127.0.0.1")).toBe(false);
+    });
+
+    it("rejects ::1", () => {
+      expect(isSafeUrl("http://[::1]")).toBe(false);
+    });
+
+    it("rejects 0.0.0.0", () => {
+      expect(isSafeUrl("http://0.0.0.0")).toBe(false);
+    });
+  });
+
+  describe("private IP ranges", () => {
+    it("rejects 10.x.x.x (10.0.0.0/8)", () => {
+      expect(isSafeUrl("http://10.0.0.1")).toBe(false);
+      expect(isSafeUrl("http://10.255.255.255")).toBe(false);
+    });
+
+    it("rejects 172.16-31.x.x (172.16.0.0/12)", () => {
+      expect(isSafeUrl("http://172.16.0.1")).toBe(false);
+      expect(isSafeUrl("http://172.31.255.255")).toBe(false);
+    });
+
+    it("allows 172.15.x.x (outside range)", () => {
+      expect(isSafeUrl("http://172.15.0.1")).toBe(true);
+    });
+
+    it("allows 172.32.x.x (outside range)", () => {
+      expect(isSafeUrl("http://172.32.0.1")).toBe(true);
+    });
+
+    it("rejects 192.168.x.x (192.168.0.0/16)", () => {
+      expect(isSafeUrl("http://192.168.0.1")).toBe(false);
+      expect(isSafeUrl("http://192.168.1.100")).toBe(false);
+    });
+
+    it("rejects 169.254.x.x (link-local)", () => {
+      expect(isSafeUrl("http://169.254.169.254")).toBe(false);
+    });
+
+    it("rejects 0.x.x.x", () => {
+      expect(isSafeUrl("http://0.1.2.3")).toBe(false);
+    });
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { getNpsCategory, slugify, formatDateDE } from "../utils";
+import { cn, getNpsCategory, slugify, formatDateDE, formatDateTimeDE } from "../utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("px-2", "py-1")).toBe("px-2 py-1");
+  });
+
+  it("deduplicates conflicting Tailwind classes", () => {
+    expect(cn("px-2", "px-4")).toBe("px-4");
+  });
+
+  it("handles conditional classes", () => {
+    expect(cn("base", false && "hidden", "end")).toBe("base end");
+  });
+});
 
 describe("getNpsCategory", () => {
   it("returns promoter for score 9", () => {
@@ -65,6 +79,25 @@ describe("formatDateDE", () => {
 
   it("formats date string in German format", () => {
     expect(formatDateDE("2026-12-25T00:00:00Z")).toBe("25.12.2026");
+  });
+});
+
+describe("formatDateTimeDE", () => {
+  it("returns em dash for null", () => {
+    expect(formatDateTimeDE(null)).toBe("—");
+  });
+
+  it("formats Date object with time", () => {
+    const date = new Date("2026-01-15T14:30:00Z");
+    const result = formatDateTimeDE(date);
+    expect(result).toContain("15.01.2026");
+    expect(result).toMatch(/\d{2}:\d{2}/);
+  });
+
+  it("formats date string with time", () => {
+    const result = formatDateTimeDE("2026-06-01T09:15:00Z");
+    expect(result).toContain("01.06.2026");
+    expect(result).toMatch(/\d{2}:\d{2}/);
   });
 });
 

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -14,9 +14,9 @@ export function isSafeUrl(urlString: string): boolean {
 
   const hostname = url.hostname.toLowerCase();
 
-  // Block localhost and loopback
+  // Block localhost and loopback (IPv6 bracket notation: [::1])
   if (
-    ["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(hostname)
+    ["localhost", "127.0.0.1", "[::1]", "::1", "0.0.0.0"].includes(hostname)
   ) {
     return false;
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         "src/lib/audit.ts",
         "src/lib/qr-pdf.ts",
         "src/lib/version.ts",
+        "src/lib/plausible.ts",
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## Summary
- **New test files:** `url-validation.test.ts` (19 tests), `constants-plans.test.ts` (3), `survey-templates.test.ts` (4)
- **Extended:** `utils.test.ts` with `cn()` and `formatDateTimeDE()` tests (+6 tests)
- **Bug fix:** `isSafeUrl()` now handles IPv6 bracket notation (`[::1]`) correctly
- **Config:** Excluded `plausible.ts` from coverage (client-only `window` API)

**Coverage: 64.7% → 98.5% lines** (threshold: 80%)

Closes #44

## Test plan
- [x] `npm run test` — 158 tests passing (13 files)
- [x] `npm run test:coverage` — all thresholds exceeded (98%+ across the board)

🤖 Generated with [Claude Code](https://claude.com/claude-code)