### PR TITLE
chore: fix remaining knip findings — clean exports, config, lint

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,13 +1,20 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "entry": [
-    "src/app/**/{page,layout,loading,error,not-found,route,default}.{ts,tsx}"
+    "src/app/**/{page,layout,loading,error,not-found,route,default}.{ts,tsx}",
+    "src/actions/*.ts"
   ],
   "project": ["src/**/*.{ts,tsx}"],
   "ignore": [
     "src/components/ui/**"
   ],
   "ignoreDependencies": [
-    "eslint-config-next"
+    "eslint-config-next",
+    "postcss-load-config",
+    "@eslint/eslintrc",
+    "@next/env"
+  ],
+  "ignoreBinaries": [
+    "gitleaks"
   ]
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, type ReactNode } from "react";
+import { createContext, useEffect, type ReactNode } from "react";
 import { type ThemeId, type ThemeConfig, getThemeConfig } from "@/lib/themes";
 
 type ThemeContextValue = {
@@ -35,8 +35,4 @@ export function ThemeProvider({
       {children}
     </ThemeContext.Provider>
   );
-}
-
-export function useTheme(): ThemeContextValue {
-  return useContext(ThemeContext);
 }

--- a/src/lib/__tests__/url-validation.test.ts
+++ b/src/lib/__tests__/url-validation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-clear-text-protocols -- SSRF tests intentionally use http:// URLs */
 import { describe, it, expect } from "vitest";
 import { isSafeUrl } from "../url-validation";
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -11,7 +11,8 @@ describe("cn", () => {
   });
 
   it("handles conditional classes", () => {
-    expect(cn("base", false && "hidden", "end")).toBe("base end");
+    const isHidden = false;
+    expect(cn("base", isHidden && "hidden", "end")).toBe("base end");
   });
 });
 

--- a/src/lib/db/queries/admin.ts
+++ b/src/lib/db/queries/admin.ts
@@ -60,7 +60,7 @@ export async function removePlanOverride(practiceId: string) {
 /**
  * Filter params for practices list.
  */
-export interface PracticesFilter {
+interface PracticesFilter {
   search?: string;
   plan?: PlanId;
   hasGoogle?: boolean;
@@ -205,7 +205,7 @@ export async function getExtendedPlatformStats() {
 // AUDIT EVENTS
 // ============================================================
 
-export interface AuditFilter {
+interface AuditFilter {
   practiceId?: string;
   action?: string;
   from?: string; // ISO date
@@ -276,7 +276,7 @@ export async function getAuditActionTypes() {
 // LOGIN EVENTS
 // ============================================================
 
-export interface LoginFilter {
+interface LoginFilter {
   practiceId?: string;
   from?: string;
   to?: string;

--- a/src/lib/review-router.ts
+++ b/src/lib/review-router.ts
@@ -1,7 +1,7 @@
 import { getNpsCategory } from "./utils";
 import { getGoogleReviewLink } from "./google";
 
-export type RouteResult = {
+type RouteResult = {
   category: "promoter" | "passive" | "detractor";
   routedTo: "google" | "internal" | null;
   googleReviewUrl: string | null;

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -82,11 +82,3 @@ export const alertNoteSchema = z.object({
   note: z.string().max(1000),
 });
 
-// ============================================================
-// TYPES
-// ============================================================
-export type LoginInput = z.infer<typeof loginSchema>;
-export type RegisterInput = z.infer<typeof registerSchema>;
-export type PracticeUpdateInput = z.infer<typeof practiceUpdateSchema>;
-export type SurveyResponseInput = z.infer<typeof surveyResponseSchema>;
-export type AlertNoteInput = z.infer<typeof alertNoteSchema>;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,4 +1,4 @@
-export interface BuildInfo {
+interface BuildInfo {
   version: string;
   hash: string;
   date: string;
@@ -22,11 +22,4 @@ export function getBuildInfo(): BuildInfo {
     branch,
     label: `${version}+${hash}`,
   };
-}
-
-/** Formatted display string: "v0.1.0 (abc1234 · 2026-02-10)" */
-export function getVersionString(): string {
-  const b = getBuildInfo();
-  const d = b.date.split("T")[0];
-  return `v${b.version} (${b.hash} · ${d})`;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,24 +1,12 @@
-// Re-export DB types
-export type {
-  Practice,
-  NewPractice,
-  Survey,
-  NewSurvey,
-  Response,
-  NewResponse,
-  Alert,
-  NewAlert,
-} from "@/lib/db/schema";
-
 // ============================================================
 // Survey Template Types
 // ============================================================
-export type SurveyTemplateId =
+type SurveyTemplateId =
   | "zahnarzt_standard"
   | "zahnarzt_kurz"
   | "zahnarzt_prophylaxe";
 
-export type SurveyQuestion = {
+type SurveyQuestion = {
   id: string;
   type: "nps" | "stars" | "freetext";
   label: string;
@@ -34,29 +22,11 @@ export type SurveyTemplate = {
 };
 
 // ============================================================
-// Dashboard Types
-// ============================================================
-export type DashboardOverview = {
-  npsScore: number | null;
-  totalResponses: number;
-  responsesThisWeek: number;
-  googleReviewClicks: number;
-  googleConversionRate: number | null;
-  unreadAlerts: number;
-  categoryScores: {
-    waitTime: number | null;
-    friendliness: number | null;
-    treatment: number | null;
-    facility: number | null;
-  };
-};
-
-// ============================================================
 // Plan Types
 // ============================================================
 export type PlanId = "free" | "starter" | "professional";
 
-export type PlanLimits = {
+type PlanLimits = {
   maxResponsesPerMonth: number;
   maxLocations: number;
   templates: SurveyTemplateId[];


### PR DESCRIPTION
## Summary
- Remove unused DB type re-exports (`Practice`, `NewPractice`, etc.) and `DashboardOverview` from `types/index.ts`
- Un-export file-internal types: `PlanLimits`, `RouteResult`, `BuildInfo`, `PracticesFilter`, `AuditFilter`, `LoginFilter`
- Remove dead code: `getVersionString()`, `useTheme` hook, 5 validation input types
- Fix knip config: add server actions entry pattern, `ignoreBinaries` (gitleaks), `ignoreDependencies` (transitive deps)
- Fix ESLint errors: disable `no-clear-text-protocols` in SSRF test file, fix redundant boolean literal in utils test

## Result
**knip: 0 findings** (was 27)

| Check | Status |
|-------|--------|
| `npm run build` | ✅ |
| `npm run typecheck` | ✅ |
| `npm run test` (158 tests) | ✅ |
| `npm run knip` | ✅ 0 findings |

Net: **-40 lines** (21 added, 61 removed)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)