### PR TITLE
chore(claude): hooks, launch.json, security-reviewer, db-migrate (#89)

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,74 @@
+# Security Reviewer Agent
+
+Review code changes for security vulnerabilities specific to this SaaS project.
+
+## Scope
+
+You are a read-only security reviewer. You do NOT write or modify code.
+Analyze the specified files or recent changes and report findings.
+
+## Checklist
+
+### 1. IDOR (Insecure Direct Object Reference)
+- Every DB query in `src/actions/` and `src/app/api/` MUST filter by `practiceId`
+- Check that ownership is verified before mutations (UPDATE, DELETE)
+- Pattern: `and(eq(table.id, id), eq(table.practiceId, practiceId))`
+
+### 2. SSRF (Server-Side Request Forgery)
+- All server-side URL fetches MUST use `isSafeUrl()` from `lib/url-validation.ts`
+- Check for `fetch()`, `axios`, or HTTP calls with user-supplied URLs
+- Verify private IP ranges are blocked (RFC-1918, link-local, loopback, IPv6)
+
+### 3. XSS (Cross-Site Scripting)
+- Email templates: all user inputs MUST use `escapeHtml()` from `lib/email.ts`
+- React unsafe HTML rendering should NOT appear outside marketing pages
+- Check Zod schemas strip HTML from user inputs
+
+### 4. DSGVO / Data Protection
+- `responses` table must NOT contain PII (no name, email, phone)
+- Session hash is for deduplication only, not tracking
+- No cookies except auth session
+- Check that survey data is anonymized
+
+### 5. Stripe Webhook Security
+- Webhook route MUST verify signature via `stripe.webhooks.constructEvent()`
+- Must use `request.text()` (not `.json()`) for raw body
+- Price IDs from env vars, not hardcoded
+
+### 6. Auth & Access Control
+- API routes MUST use `requireAuthForApi()` from `lib/auth.ts`
+- Admin routes MUST use `requireAdmin()`
+- Server Actions MUST validate with Zod before DB operations
+- Check for missing auth checks on new endpoints
+
+### 7. Input Validation
+- All inputs validated with Zod schemas from `lib/validations.ts`
+- UUIDs validated as proper UUID format
+- No raw SQL — all queries via Drizzle ORM
+- Extra keys in request bodies must be rejected
+
+### 8. Secret Management
+- No hardcoded secrets, API keys, or passwords
+- Environment variables accessed via `process.env` only
+- `.env*` files in `.gitignore`
+
+## Output Format
+
+Report findings as:
+```
+## Security Review — [files/scope]
+
+### Critical (must fix before merge)
+- [finding with file:line reference]
+
+### Warning (should fix)
+- [finding with file:line reference]
+
+### Info (best practice suggestion)
+- [finding]
+
+### Passed
+- [checks that passed]
+```
+
+If no issues found, confirm: "No security issues found in reviewed files."

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Next.js Dev Server",
+    "type": "node",
+    "runtimeExecutable": "node",
+    "command": "node_modules/next/dist/bin/next",
+    "args": ["dev", "--turbopack"],
+    "port": 3000,
+    "env": {
+      "NODE_OPTIONS": "--dns-result-order=ipv4first"
+    }
+  },
+  {
+    "name": "Drizzle Studio",
+    "type": "node",
+    "runtimeExecutable": "node",
+    "command": "node_modules/drizzle-kit/bin.cjs",
+    "args": ["studio"],
+    "port": 4983
+  }
+]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const f=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); const p=f.tool_input?.file_path||''; if(/\\.(ts|tsx)$/.test(p)){const{execFileSync}=require('child_process'); try{execFileSync('npx',['eslint','--fix',p.replace(/\\\\\\\\/g,'/')],{stdio:'pipe',timeout:15000})}catch(e){const out=(e.stderr||e.stdout||'').toString(); if(out.includes('error')){console.error('ESLint errors in '+p); process.exit(1)}}}\"",
+            "timeout": 20000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const f=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); const p=f.tool_input?.file_path||''; if(/\\.env/.test(p)){console.error('Warning: .env files should be edited manually, not via Claude.'); process.exit(1)}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/db-migrate/SKILL.md
+++ b/.claude/skills/db-migrate/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: db-migrate
+description: Drizzle ORM DB-Workflow — Schema generieren, pushen, Studio öffnen, Status prüfen.
+argument-hint: "<generate|push|studio|status>"
+disable-model-invocation: true
+---
+
+Führe den Drizzle DB-Workflow aus basierend auf dem Argument `$ARGUMENTS`:
+
+## Befehle
+
+### `generate`
+1. Führe aus: `npx drizzle-kit generate`
+2. Zeige die generierten SQL-Dateien in `drizzle/`
+3. Hinweis: Bei ambigen Schema-Änderungen (rename vs. create) wird drizzle-kit interaktiv — ggf. `--custom` verwenden und SQL manuell schreiben
+
+### `push`
+1. Warnung: `push` ist destruktiv — Daten können verloren gehen!
+2. Frage nach Bestätigung bevor du fortfährst
+3. Führe aus: `npm run db:push`
+4. Zeige Ergebnis
+
+### `studio`
+1. Führe aus: `node node_modules/drizzle-kit/bin.cjs studio` (im Hintergrund)
+2. Hinweis: Drizzle Studio läuft auf Port 4983
+
+### `status`
+1. Zeige aktuelle Schema-Datei: `src/lib/db/schema.ts`
+2. Liste Migrations in `drizzle/` auf
+3. Zeige die Anzahl der Tabellen im Schema
+
+## Regeln
+- Alle Schema-Änderungen NUR in `src/lib/db/schema.ts`
+- UUIDs als Primary Keys
+- `created_at` + `updated_at` auf allen Tabellen
+- Kein Raw SQL — alles über Drizzle ORM
+- `drizzle/meta/` Snapshots sind gitignored — nur SQL committed


### PR DESCRIPTION
## Summary
- **Hooks** (`settings.json`): Auto-Lint nach Edit/Write auf `.ts/.tsx`, Block `.env` Edits
- **launch.json**: Next.js Dev Server (Turbopack, Port 3000) + Drizzle Studio (Port 4983)
- **security-reviewer** Agent: Read-only Security-Audit (IDOR, SSRF, XSS, DSGVO, Stripe, Auth)
- **db-migrate** Skill: `/db-migrate <generate|push|studio|status>` für Drizzle-Workflows

## Test plan
- [ ] Neue Session starten, `.ts` Datei editieren → ESLint Hook triggert
- [ ] `.env` editieren → Block-Warnung erscheint
- [ ] Dev-Server über Claude Preview starten → Port 3000
- [ ] `/db-migrate status` ausführen → Schema-Info angezeigt
- [ ] Security-Reviewer Agent aufrufen → Report ohne Code-Änderungen

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)